### PR TITLE
Fix scripts for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "test": "./node_modules/jasmine-node/bin/jasmine-node --test-dir ./"
-  },
-  "dependencies": {
+    "test": "jasmine-node --test-dir ./"
   },
   "devDependencies": {
     "jasmine-core": "2.3.4",


### PR DESCRIPTION
An `npm` installation of jasmine-node installs two files in `node_modules/.bin`, one of which is `jasmine-node.cmd`. This PR takes advantage of this and ensure the tests run on both Windows and *nix systems.

```
z:\Documents\GitHub\halo\event-dispatcher-test>npm test

> @ test z:\Documents\GitHub\halo\event-dispatcher-test
> jasmine-node --test-dir ./

.

Finished in 0.005 seconds
1 test, 1 assertion, 0 failures, 0 skipped
```

And in bash...

```
/.../halo/event-dispatcher-test (fix-windows)$npm test

> @ test Z:\Documents\GitHub\halo\event-dispatcher-test
> jasmine-node --test-dir ./

.

Finished in 0.004 seconds
1 test, 1 assertion, 0 failures, 0 skipped
```