### PR TITLE
Support ES6 objects with eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
     "root": true,
     "env": {
-        "node": true
+        "node": true,
+        "es6": true
     },
     "extends":[
         "eslint:recommended"


### PR DESCRIPTION
When running `npm test` I would get an error about `Map` being undefined. Some research pointed me to https://github.com/eslint/eslint/issues/5674 which said that we need to set an environment variable for eslint to work properly.